### PR TITLE
초기 환경설정 완료

### DIFF
--- a/src/main/java/com/github/hanpyo/config/JpaConfig.java
+++ b/src/main/java/com/github/hanpyo/config/JpaConfig.java
@@ -1,0 +1,9 @@
+package com.github.hanpyo.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@Configuration
+@EnableJpaAuditing
+public class JpaConfig {
+}

--- a/src/main/java/com/github/hanpyo/config/QuerydslConfig.java
+++ b/src/main/java/com/github/hanpyo/config/QuerydslConfig.java
@@ -1,0 +1,22 @@
+package com.github.hanpyo.config;
+
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@RequiredArgsConstructor
+public class QuerydslConfig {
+
+	@PersistenceContext
+	private final EntityManager em;
+
+	@Bean
+	public JPAQueryFactory jpaQueryFactory() {
+		return new JPAQueryFactory(em);
+	}
+}

--- a/src/main/java/com/github/hanpyo/entity/AbstractBaseTimeEntity.java
+++ b/src/main/java/com/github/hanpyo/entity/AbstractBaseTimeEntity.java
@@ -1,0 +1,20 @@
+package com.github.hanpyo.entity;
+
+import java.time.LocalDateTime;
+import javax.persistence.EntityListeners;
+import javax.persistence.MappedSuperclass;
+
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class AbstractBaseTimeEntity {
+
+	@CreatedDate
+	protected LocalDateTime createdAt;
+
+	@LastModifiedDate
+	protected LocalDateTime updatedAt;
+}

--- a/src/test/java/com/github/hanpyo/test/IntegrationTest.java
+++ b/src/test/java/com/github/hanpyo/test/IntegrationTest.java
@@ -1,0 +1,34 @@
+package com.github.hanpyo.test;
+
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+
+import com.github.hanpyo.HanpyoApplication;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import org.junit.jupiter.api.Disabled;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+@SpringBootTest(classes = {HanpyoApplication.class})
+@Import({JpaTestSupport.class})
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+@Disabled
+public abstract class IntegrationTest {
+
+	@Autowired
+	protected MockMvc mockMvc;
+
+	@PersistenceContext
+	protected EntityManager em;
+
+	@Autowired
+	protected JPAQueryFactory jpaQueryFactory;
+
+	@Autowired
+	protected JpaTestSupport jpaTestSupport;
+}

--- a/src/test/java/com/github/hanpyo/test/JpaTest.java
+++ b/src/test/java/com/github/hanpyo/test/JpaTest.java
@@ -1,0 +1,25 @@
+package com.github.hanpyo.test;
+
+import com.github.hanpyo.config.JpaConfig;
+import com.github.hanpyo.config.QuerydslConfig;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import org.junit.jupiter.api.Disabled;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+
+@DataJpaTest
+@Import({JpaConfig.class, QuerydslConfig.class, JpaTestSupport.class})
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@ActiveProfiles("test")
+@Disabled
+public abstract class JpaTest {
+
+	@Autowired
+	protected JPAQueryFactory jpaQueryFactory;
+
+	@Autowired
+	protected JpaTestSupport jpaTestSupport;
+}

--- a/src/test/java/com/github/hanpyo/test/JpaTestSupport.java
+++ b/src/test/java/com/github/hanpyo/test/JpaTestSupport.java
@@ -1,0 +1,99 @@
+package com.github.hanpyo.test;
+
+import javax.persistence.EntityManager;
+import javax.persistence.EntityManagerFactory;
+import javax.persistence.EntityTransaction;
+
+import com.querydsl.core.types.EntityPath;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import org.springframework.boot.test.context.TestComponent;
+
+@TestComponent
+public class JpaTestSupport {
+
+	private final EntityManagerFactory emf;
+
+	public JpaTestSupport(EntityManagerFactory emf) {
+		this.emf = emf;
+	}
+
+	public <T> T save(T entity) {
+		EntityManager em = entityManager();
+		EntityTransaction trx = em.getTransaction();
+		try {
+			trx.begin();
+			em.persist(entity);
+			trx.commit();
+			em.clear();
+			return entity;
+		} catch (Exception e) {
+			trx.rollback();
+		} finally {
+			em.close();
+		}
+		return null;
+	}
+
+	public <T> Iterable<T> saveAll(Iterable<T> entities) {
+		EntityManager em = entityManager();
+		EntityTransaction trx = em.getTransaction();
+		try {
+			trx.begin();
+			for (T e : entities) {
+				em.persist(e);
+			}
+			trx.commit();
+			em.clear();
+			return entities;
+		} catch (Exception e) {
+			trx.rollback();
+		} finally {
+			em.close();
+		}
+		return null;
+	}
+
+	public void deleteAll(EntityPath<?> path) {
+		EntityManager em = entityManager();
+		JPAQueryFactory jpaQueryFactory = jpaQueryFactory(em);
+		EntityTransaction trx = em.getTransaction();
+		try {
+			trx.begin();
+
+			jpaQueryFactory.delete(path).execute();
+
+			trx.commit();
+			em.clear();
+		} catch (Exception e) {
+			trx.rollback();
+		} finally {
+			em.close();
+		}
+	}
+
+	public void deleteAllFromAllTables() {
+		EntityManager em = entityManager();
+		JPAQueryFactory jpaQueryFactory = jpaQueryFactory(em);
+		EntityTransaction trx = em.getTransaction();
+		try {
+			trx.begin();
+
+			// 모든 테이블 삭제하는 쿼리 실행
+
+			trx.commit();
+			em.clear();
+		} catch (Exception e) {
+			trx.rollback();
+		} finally {
+			em.close();
+		}
+	}
+
+	private EntityManager entityManager() {
+		return emf.createEntityManager();
+	}
+
+	private JPAQueryFactory jpaQueryFactory(EntityManager em) {
+		return new JPAQueryFactory(em);
+	}
+}

--- a/src/test/java/com/github/hanpyo/test/MockTest.java
+++ b/src/test/java/com/github/hanpyo/test/MockTest.java
@@ -1,0 +1,12 @@
+package com.github.hanpyo.test;
+
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.context.ActiveProfiles;
+
+@ExtendWith(MockitoExtension.class)
+@ActiveProfiles("test")
+@Disabled
+public abstract class MockTest {
+}


### PR DESCRIPTION
#1

### JPA 설정
- 엔티티 생성 및 수정 시 생성날짜, 수정날짜 자동 입력되도록 설정 -> 엔티티에서 AbstractBaseTimeEntity 상속할 것
- JpaQueryFactory를 빈으로 등록함

### 테스트 추상 클래스
- IntegrationTest: 통합 테스트 추상 클래스
- JpaTest: JPA 테스트 추상 클래스
- MockTest: 모킹 테스트 추상 클래스함
- JpaTestSupport: 트랜잭션 분리를 위한 테스트용 클래스