### PR TITLE
이메일 및 닉네임 중복 확인 API 구현 완료

### DIFF
--- a/src/main/java/com/github/hanpyo/repository/CustomMemberRepository.java
+++ b/src/main/java/com/github/hanpyo/repository/CustomMemberRepository.java
@@ -1,0 +1,8 @@
+package com.github.hanpyo.repository;
+
+public interface CustomMemberRepository {
+
+	boolean existsByEmail(String email);
+
+	boolean existsByNickname(String nickname);
+}

--- a/src/main/java/com/github/hanpyo/repository/CustomMemberRepositoryImpl.java
+++ b/src/main/java/com/github/hanpyo/repository/CustomMemberRepositoryImpl.java
@@ -1,0 +1,32 @@
+package com.github.hanpyo.repository;
+
+import static com.github.hanpyo.entity.QMember.*;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class CustomMemberRepositoryImpl implements CustomMemberRepository {
+
+	private final JPAQueryFactory jpaQueryFactory;
+
+	@Override
+	public boolean existsByEmail(String email) {
+		Integer one = jpaQueryFactory.selectOne()
+			.from(member)
+			.where(member.email.eq(email))
+			.fetchOne();
+		return one != null;
+	}
+
+	@Override
+	public boolean existsByNickname(String nickname) {
+		Integer one = jpaQueryFactory.selectOne()
+			.from(member)
+			.where(member.nickname.eq(nickname))
+			.fetchOne();
+		return one != null;
+	}
+}

--- a/src/main/java/com/github/hanpyo/repository/MemberRepository.java
+++ b/src/main/java/com/github/hanpyo/repository/MemberRepository.java
@@ -5,7 +5,7 @@ import java.util.Optional;
 import com.github.hanpyo.entity.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface MemberRepository extends JpaRepository<Member, Long> {
+public interface MemberRepository extends JpaRepository<Member, Long>, CustomMemberRepository {
 
 	Optional<Member> findByEmail(String email);
 

--- a/src/main/java/com/github/hanpyo/resolver/RootMemberQueryResolver.java
+++ b/src/main/java/com/github/hanpyo/resolver/RootMemberQueryResolver.java
@@ -3,6 +3,7 @@ package com.github.hanpyo.resolver;
 import com.github.hanpyo.config.security.MemberDetails;
 import com.github.hanpyo.dto.MemberDto;
 import com.github.hanpyo.exception.WrongSessionException;
+import com.github.hanpyo.repository.MemberRepository;
 import com.github.hanpyo.service.MemberService;
 import graphql.kickstart.tools.GraphQLQueryResolver;
 import lombok.RequiredArgsConstructor;
@@ -15,6 +16,7 @@ import org.springframework.stereotype.Component;
 public class RootMemberQueryResolver implements GraphQLQueryResolver {
 
 	private final MemberService memberService;
+	private final MemberRepository memberRepository;
 
 	@PreAuthorize("hasRole('VERIFIED_MEMBER')")
 	public MemberDto myMemberInfo() {
@@ -24,5 +26,13 @@ public class RootMemberQueryResolver implements GraphQLQueryResolver {
 		}
 		MemberDetails memberDetails = (MemberDetails)principal;
 		return memberService.getMemberById(memberDetails.getId());
+	}
+
+	public boolean memberDuplicatedByEmail(String email) {
+		return memberRepository.existsByEmail(email);
+	}
+
+	public boolean memberDuplicatedByNickname(String nickname) {
+		return memberRepository.existsByNickname(nickname);
 	}
 }

--- a/src/main/resources/schema.graphqls
+++ b/src/main/resources/schema.graphqls
@@ -2,6 +2,8 @@ scalar Long
 
 type Query {
     myMemberInfo: Member!
+    memberDuplicatedByEmail(email: String!): Boolean!
+    memberDuplicatedByNickname(nickname: String!): Boolean!
 }
 
 type Mutation {

--- a/src/test/java/com/github/hanpyo/repository/CustomMemberRepositoryImplTest.java
+++ b/src/test/java/com/github/hanpyo/repository/CustomMemberRepositoryImplTest.java
@@ -1,0 +1,74 @@
+package com.github.hanpyo.repository;
+
+import static org.assertj.core.api.BDDAssertions.*;
+
+import com.github.hanpyo.entity.Member;
+import com.github.hanpyo.test.JpaTest;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+public class CustomMemberRepositoryImplTest extends JpaTest {
+
+	@Autowired
+	private CustomMemberRepositoryImpl customMemberRepository;
+
+	@Test
+	public void existsByEmailThenReturnsFalse() {
+		// given
+		String givenEmail = "youngxpepp@gmail.com";
+
+		// when
+		boolean result = customMemberRepository.existsByEmail(givenEmail);
+
+		// then
+		then(result).isFalse();
+	}
+
+	@Test
+	public void existsByEmailThenReturnsTrue() {
+		// given
+		Member existMember = Member.builder()
+			.email("youngxpepp@gmail.com")
+			.build();
+		em.persist(existMember);
+
+		em.flush();
+		em.clear();
+
+		// when
+		boolean result = customMemberRepository.existsByEmail(existMember.getEmail());
+
+		// then
+		then(result).isTrue();
+	}
+
+	@Test
+	public void existsByNicknameThenReturnsFalse() {
+		// given
+		String givenNickname = "youngxpepp";
+
+		// when
+		boolean result = customMemberRepository.existsByNickname(givenNickname);
+
+		// then
+		then(result).isFalse();
+	}
+
+	@Test
+	public void existsByNicknameThenReturnsTrue() {
+		// given
+		Member existMember = Member.builder()
+			.nickname("youngxpepp")
+			.build();
+		em.persist(existMember);
+
+		em.flush();
+		em.clear();
+
+		// when
+		boolean result = customMemberRepository.existsByNickname(existMember.getNickname());
+
+		// then
+		then(result).isTrue();
+	}
+}

--- a/src/test/java/com/github/hanpyo/test/JpaTest.java
+++ b/src/test/java/com/github/hanpyo/test/JpaTest.java
@@ -1,5 +1,8 @@
 package com.github.hanpyo.test;
 
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+
 import com.github.hanpyo.config.JpaConfig;
 import com.github.hanpyo.config.QuerydslConfig;
 import com.querydsl.jpa.impl.JPAQueryFactory;
@@ -22,4 +25,7 @@ public abstract class JpaTest {
 
 	@Autowired
 	protected JpaTestSupport jpaTestSupport;
+
+	@PersistenceContext
+	protected EntityManager em;
 }


### PR DESCRIPTION
## 📑 제목

이메일 및 닉네임 중복 확인 API 구현 완료 #14

<선택> 이미지 첨부


## 💬 작업 내용

> 구현 내용 및 작업 했던 내역

- [x] 회원 이메일 중복 확인 쿼리
- [x] 회원 닉네임 중복 확인 쿼리
- [x] Repository 테스트 작성

## 🚧 PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- 닉네임 한/영 제한, 길이 제한 등등의 상세 조건들 어떻게 할 것인지?